### PR TITLE
Add min-with to body element

### DIFF
--- a/assets/scss/elements/body.scss
+++ b/assets/scss/elements/body.scss
@@ -9,5 +9,5 @@ body {
   color: #000;
   margin: 0;
   padding: 0;
-  min-width:50rem;
+  min-width: 50rem;
 }

--- a/assets/scss/elements/body.scss
+++ b/assets/scss/elements/body.scss
@@ -9,4 +9,5 @@ body {
   color: #000;
   margin: 0;
   padding: 0;
+  min-width:50rem;
 }


### PR DESCRIPTION
Hi,
Firstly I want to thank you for making so easy to deploy Nuxt&Storyblok. Also, its tutorial is amazing.
I've added a css line for the body element to avoid the BottomFooter to be cut and become shorter than the TopHeader and Page vue components. This is visible on small windows like mobile screens.
Attached screenshots before and after the modification.

BEFORE:
![before min-width](https://user-images.githubusercontent.com/13556706/47002779-28eb2500-d12e-11e8-9b5f-ba09764bc678.png)

AFTER:
![after min-width](https://user-images.githubusercontent.com/13556706/47002809-34d6e700-d12e-11e8-98c6-7e5826ece40f.png)






